### PR TITLE
fix: prevent losing result status

### DIFF
--- a/config/extendedStylelintOrderConfig.js
+++ b/config/extendedStylelintOrderConfig.js
@@ -8,7 +8,6 @@ module.exports = ({
 } = {}) => ({
   plugins: ['stylelint-order', path.join(__dirname, '../plugin')],
   rules: {
-    'order/properties-order': [],
     'property-no-unknown': [
       true,
       {

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -3,6 +3,7 @@ const propertiesOrderRule = require('stylelint-order/rules/properties-order');
 const configCreator = require('../config/configCreator');
 
 const ruleName = 'plugin/rational-order';
+const propertiesOrderRuleName = propertiesOrderRule.ruleName;
 
 module.exports = stylelint.createPlugin(
   ruleName,
@@ -27,6 +28,12 @@ module.exports = stylelint.createPlugin(
     if (!enabled || !validOptions) {
       return;
     }
+
+    const resultStylelint = postcssResult.stylelint;
+    resultStylelint.ruleSeverities[propertiesOrderRuleName] = resultStylelint.ruleSeverities[ruleName];
+    resultStylelint.customMessages[propertiesOrderRuleName] = resultStylelint.customMessages[ruleName];
+    resultStylelint.ruleMetadata[propertiesOrderRuleName] = resultStylelint.ruleMetadata[ruleName];
+
     const expectation = configCreator(options);
     propertiesOrderRule(
       expectation,


### PR DESCRIPTION
Fixed losing result status. This issue did cause bad messages and incorrect exit code of stylelint.

Before:
![image](https://user-images.githubusercontent.com/10081538/172022910-10c009d4-203e-4021-ac3d-0294e899d74f.png)
After:
![image](https://user-images.githubusercontent.com/10081538/172022922-58b9fd1f-27f8-4ab4-8b59-0b650dd4a318.png)

Also fixed double invocation of `order/properties-order`.